### PR TITLE
fix: Python 3.4.0 print the version info to stdout

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,8 @@ function pythonVersion (python, callback) {
 
     var m = stderr.toString().match(/^Python (\d)[.\d]+/i)
     if (!m)
+      m = stdout.toString().match(/^Python (\d)[.\d]+/i)
+    if (!m)
       return callback(new Error('Cannot determine Python version: [' + stderr.toString() + ']'))
 
     pythonVersions[python] = +m[1]


### PR DESCRIPTION
Python 3.4.0 print the version info to stdout but not stderr.
