### PR TITLE
Added possibility to specify End of Line character in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Language/lexer, formatter, and their options are currently supported. Filters ar
 * `lang`: source language/lexer name - `String`
 * `format`: output formatter name - `String`
 * `python`: the full path to the `python` command on the current system, defaults to `'python'` - `String`
+* `eol`: desired End of Line marker in output, defaults to yours OS End od Line char - `String`
 * `options`: lexer and formatter options, each key/value pair is passed through to `pygmentize` with `-P` - `Object`
 
 ## Examples

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function pygmentize (options, code, callback) {
     if (err)
       return callback(err)
     if (toString)
-      return fromString(child, code, options.options, callback)
+      return fromString(child, code, options, callback)
     fromStream(retStream, intStream, options, child)
   })
 

--- a/test.js
+++ b/test.js
@@ -30,7 +30,7 @@ function simpleStringConversionTest (python) {
           , {
                 lang: 'php'
               , format: 'html'
-              , options: { startinline: 1, eol: '\n' }
+              , options: { startinline: 1 }
               , input: 'var a = true;'
               , output: '<div class="highlight"><pre><span class="k">var</span> <span class="nx">a</span> '
                   + '<span class="o">=</span> <span class="k">true</span><span class="p">;</span></pre></div>'
@@ -38,9 +38,9 @@ function simpleStringConversionTest (python) {
           , {
                 lang: 'python'
               , format: 'html'
-              , options: { eol: '\r' }
               , input: '#a\n'
               , output: '<div class="highlight"><pre><span class="c">#a</span>\r</pre></div>\r'
+              , eol: '\r'
             }
         ]
 
@@ -51,8 +51,9 @@ function simpleStringConversionTest (python) {
           {
               lang    : c.lang
             , format  : c.format
-            , options : c.options || { eol: '\n' }
+            , options : c.options || {}
             , python  : python
+            , eol     : c.eol || '\n'
           }
         , c.input
         , function (err, result) {


### PR DESCRIPTION
## What's the issue?

Currently **node-pygmentize-bundled** adds OS-specific line endings to output, even if input source code has diffrent line endings. I've faced this issue while working with grunt plugin which is using this project.

Since Windows by default uses `\r\n` as its EOL, it started to result with files having both `\n` and `\r\n` mixed in.

I've started to dig it a little bit, and tested Pygments itself, but it was managing EOLs as expected.

Because of this issue **node-pygmentize-bundled** tests were failing too at Win.
## Design concept:

I didn't change the defalut behaviour, lines will be changes only when the `options.eol` property will be set - this way it will keep backward compatibility.

I've added a note to options list in **README.md**.
## What I've done here?
### index.js modifications:

Changes went to both `fromString` and `fromStream` functions.
- Added a `osEolRegExp` variable, which will store a RegExp for OS EOL.
- I've added extra parameter, `options`. Options allows us to check desired EOL markers.
- Logic, which will handle a case, when `options.eol` was explicitly specified:
  - if expected EOL is the same as current OS, we don't need to do any extra steps.
  - if OS EOL differs from expected, we need to replace all the OS specific markers.
### test.js modifications:
- I've added `options.eol = "\n"` in each TC, since this is the case that we want to work with.
- I've created extra TC to make sure that fix is working.
## Extra thoughts

I didn't test this solution on Mac, so it might be a good idea to check it there.
